### PR TITLE
GitHub Actionsのリストから削除

### DIFF
--- a/tool/vscode/README.md
+++ b/tool/vscode/README.md
@@ -16,7 +16,6 @@
 * Markdown All in One
 * Markdown Table
 * GitHub Copilot
-* GitHub Actions
 
 ## フォント
 BIZ UDゴシックを導入（`setting.json`に記載済み、デフォルトのフォントに追加している）


### PR DESCRIPTION
This pull request includes a small change to the `tool/vscode/README.md` file. The change removes "GitHub Actions" from the list of recommended extensions.