### PR TITLE
msys2 の db_home 設定について説明を追加

### DIFF
--- a/os/windows/README.md
+++ b/os/windows/README.md
@@ -138,6 +138,7 @@ Windows向けのソフトウェア構築環境。LinuxライクなツールとCM
 ### 設定
 
 * `MSYS2_PATH_TYPE`を設定するとPATHを制御できる
+* `/etc/nsswitch.conf` の `db_home` を `windows` に設定することで、ホームディレクトリを Windows のユーザープロフィール配下（`C:\Users\ユーザー名`）に変更できる。これにより Windows ネイティブツールとの統合が容易になる。
 
 ## WSL2
 ### インストール


### PR DESCRIPTION
## 概要

msys2 セクション内の設定について、`/etc/nsswitch.conf` の `db_home` パラメータに関する説明を追加しました。

## 変更内容

- `db_home` を `windows` に設定することで、ホームディレクトリを Windows のユーザープロフィール配下（`C:\Users\ユーザー名`）に変更できることを説明
- Windows ネイティブツールとの統合が容易になる利点を記載

## 理由

msys2 を使用する際に、ホームディレクトリの設定はよく問題になるため、設定方法と効果を明確に記録することで、今後の参考になると考えます。