### PR TITLE
docs: MSYS2 の PATH_TYPE と nsswitch.conf 設定を詳述

### DIFF
--- a/os/windows/README.md
+++ b/os/windows/README.md
@@ -137,8 +137,12 @@ Windows向けのソフトウェア構築環境。LinuxライクなツールとCM
 
 ### 設定
 
-* `MSYS2_PATH_TYPE`を設定するとPATHを制御できる
-* `/etc/nsswitch.conf` の `db_home` を `windows` に設定することで、ホームディレクトリを Windows のユーザープロフィール配下（`C:\Users\ユーザー名`）に変更できる。これにより Windows ネイティブツールとの統合が容易になる。
+* `MSYS2_PATH_TYPE=inherit`
+    * MSYS2 ルートディレクトリ直下の `.ini` ファイル（例：`C:\msys64\ucrt64.ini`）に `MSYS2_PATH_TYPE=inherit` を記述する
+    * Windows の PATH 変数を MSYS2 シェルに継承し、Windows ネイティブツールへのアクセスが容易になる
+* `/etc/nsswitch.conf`
+    * MSYS2 ルートディレクトリ直下の `/etc/nsswitch.conf` ファイル（例：`C:\msys64\etc\nsswitch.conf`）の `db_home` を `windows` に設定する
+    * ホームディレクトリを Windows のユーザープロフィール配下（`C:\Users\ユーザー名`）に変更でき、Windows ネイティブツールとの統合が容易になる
 
 ## WSL2
 ### インストール


### PR DESCRIPTION
## Summary
MSYS2 の設定について、`MSYS2_PATH_TYPE=inherit` と `nsswitch.conf` の詳細な設定方法を追記しました。

## Changes
- `MSYS2_PATH_TYPE=inherit` について、`.ini` ファイルの具体的なパスと設定方法を説明
- Windows の PATH 変数を継承し、ネイティブツールへのアクセスが容易になることを記載
- `nsswitch.conf` のファイル場所（`C:\msys64\etc\nsswitch.conf`）を明記し、`db_home` を `windows` に設定する方法を説明

## Details
ユーザーが MSYS2 を設定する際に、ファイルの正確なパスが分かるようにしました。これにより、Windows とのツール統合がより容易になります。